### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ docker run -d \
   -e MYSQL_DATABASE='wewe-rss' \
   -v db_data:/var/lib/mysql \
   --network wewe-rss \
-  mysql:latest --default-authentication-plugin=mysql_native_password
+  mysql:latest --mysql-native-password=ON
 ```
 
 3. 启动 Server


### PR DESCRIPTION
根据[官方指引](https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html)修改最新版 MySQL 启用插件方式

Important Change: The deprecated mysql_native_password authentication plugin is now disabled by default. It can be enabled by starting MySQL with the new [--mysql-native-password=ON](https://dev.mysql.com/doc/refman/8.4/en/server-options.html#option_mysqld_mysql-native-password) server option, or by adding mysql_native_password=ON to the [mysqld] section of your MySQL configuration file.

Fixes #154 