### PR TITLE
extend filter and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [x]  所有订阅源导出OPML
 - [x]  支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed：使用title_include和title_exclude参数对标题进行过滤，使用`|`支持多个关键词的 或 逻辑
 > {{ORIGIN_URL}}/feeds/filter.atom?title_include=张三
+> 
 > {{ORIGIN_URL}}/feeds/MP_WXS_123.json?limit=30&title_include=张三|李四|王五&title_exclude=张三丰|赵六
 - [x]  支持通过/feeds/:feed接口触发单个feedid更新：使用update=true参数（实时返回结果不包含更新后的articles，要获取更新后的articles需去掉update参数再请求一次）
 > {{ORIGIN_URL}}/feeds/MP_WXS_123.rss?update=true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - [x]  支持全文内容输出，让阅读无障碍
 - [x]  所有订阅源导出OPML
 - [x]  支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed：使用title_include和title_exclude参数对标题进行过滤，使用`|`支持多个关键词的 或 逻辑
-> {{ORIGIN_URL}}/feeds/filter.atom?title_include=张三
+> {{ORIGIN_URL}}/feeds/all.atom?title_include=张三
 > 
 > {{ORIGIN_URL}}/feeds/MP_WXS_123.json?limit=30&title_include=张三|李四|王五&title_exclude=张三丰|赵六
 - [x]  支持通过/feeds/:feed接口触发单个feedid更新：使用update=true参数（实时返回结果不包含更新后的articles，要获取更新后的articles需去掉update参数再请求一次）

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 - [x]  微信公众号RSS生成（支持`.atom`\.`rss`\.`json`格式)
 - [x]  支持全文内容输出，让阅读无障碍
 - [x]  所有订阅源导出OPML
+- [x]  支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed：使用title_include和title_exclude参数对标题进行过滤，使用`|`支持多个关键词的 或 逻辑
+> {{ORIGIN_URL}}/feeds/filter.atom?title_include=张三
+> {{ORIGIN_URL}}/feeds/MP_WXS_123.json?limit=30&title_include=张三|李四|王五&title_exclude=张三丰|赵六
+- [x]  支持通过/feeds/:feed接口触发单个feedid更新：使用update=true参数（实时返回结果不包含更新后的articles，要获取更新后的articles需去掉update参数再请求一次）
+> {{ORIGIN_URL}}/feeds/MP_WXS_123.rss?update=true
 
 ## 部署
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [x]  微信公众号RSS生成（支持`.atom`\.`rss`\.`json`格式)
 - [x]  支持全文内容输出，让阅读无障碍
 - [x]  所有订阅源导出OPML
-- [x]  支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed：使用title_include和title_exclude参数对标题进行过滤，使用`|`支持多个关键词的 或 逻辑
+- [x]  支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed对标题进行过滤：使用title_include和title_exclude参数，支持使用`|`实现多个关键词的 或 逻辑
 > {{ORIGIN_URL}}/feeds/all.atom?title_include=张三
 > 
 > {{ORIGIN_URL}}/feeds/MP_WXS_123.json?limit=30&title_include=张三|李四|王五&title_exclude=张三丰|赵六

--- a/apps/server/src/feeds/feeds.controller.ts
+++ b/apps/server/src/feeds/feeds.controller.ts
@@ -55,9 +55,15 @@ export class FeedsController {
     @Query('mode') mode: string,
     @Query('title_include') title_include: string,
     @Query('title_exclude') title_exclude: string,
+    @Query('update') update: boolean = false,
   ) {
     const [id, type] = feed.split('.');
     this.logger.log('getFeed: ', id);
+
+    if(update) {
+      this.feedsService.updateFeed(id);
+    }
+
     const { content, mimeType } = await this.feedsService.handleGenerateFeed({
       id,
       type,

--- a/apps/server/src/feeds/feeds.controller.ts
+++ b/apps/server/src/feeds/feeds.controller.ts
@@ -29,13 +29,18 @@ export class FeedsController {
     @Response() res: Res,
     @Query('limit', new DefaultValuePipe(30), ParseIntPipe) limit: number = 30,
     @Query('mode') mode: string,
+    @Query('title_include') title_include: string,
+    @Query('title_exclude') title_exclude: string,
   ) {
     const path = req.path;
     const type = path.split('.').pop() || '';
+
     const { content, mimeType } = await this.feedsService.handleGenerateFeed({
       type,
       limit,
       mode,
+      title_include,
+      title_exclude,
     });
 
     res.setHeader('Content-Type', mimeType);
@@ -48,6 +53,8 @@ export class FeedsController {
     @Param('feed') feed: string,
     @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number = 10,
     @Query('mode') mode: string,
+    @Query('title_include') title_include: string,
+    @Query('title_exclude') title_exclude: string,
   ) {
     const [id, type] = feed.split('.');
     this.logger.log('getFeed: ', id);
@@ -56,6 +63,8 @@ export class FeedsController {
       type,
       limit,
       mode,
+      title_include,
+      title_exclude,
     });
 
     res.setHeader('Content-Type', mimeType);

--- a/apps/server/src/feeds/feeds.service.ts
+++ b/apps/server/src/feeds/feeds.service.ts
@@ -6,7 +6,7 @@ import { feedMimeTypeMap, feedTypes } from '@server/constants';
 import { ConfigService } from '@nestjs/config';
 import { Article, Feed as FeedInfo } from '@prisma/client';
 import { ConfigurationType } from '@server/configuration';
-import { Feed } from 'feed';
+import { Feed, Item } from 'feed';
 import got, { Got } from 'got';
 import { load } from 'cheerio';
 import { minify } from 'html-minifier';
@@ -215,11 +215,15 @@ export class FeedsService {
     type,
     limit,
     mode,
+    title_include,
+    title_exclude,
   }: {
     id?: string;
     type: string;
     limit: number;
     mode?: string;
+    title_include?: string;
+    title_exclude?: string;
   }) {
     if (!feedTypes.includes(type as any)) {
       type = 'atom';
@@ -261,7 +265,18 @@ export class FeedsService {
     }
 
     this.logger.log('handleGenerateFeed articles: ' + articles.length);
-    const feed = await this.renderFeed({ feedInfo, articles, type, mode });
+    let feed = await this.renderFeed({ feedInfo, articles, type, mode });
+
+    if (title_include) {
+      const includes = title_include.split('|');
+      feed.items = feed.items.filter(
+        (i: Item) => includes.some((k) => i.title.includes(k)));
+    }
+    if (title_exclude) {
+      const excludes = title_exclude.split('|');
+      feed.items = feed.items.filter(
+        (i: Item) => !excludes.some((k) => i.title.includes(k)));
+    }
 
     switch (type) {
       case 'rss':

--- a/apps/server/src/feeds/feeds.service.ts
+++ b/apps/server/src/feeds/feeds.service.ts
@@ -303,4 +303,15 @@ export class FeedsService {
       };
     });
   }
+
+  async updateFeed(id: string) {
+    try {
+      await this.trpcService.refreshMpArticlesAndUpdateFeed(id);
+    } catch (err) {
+      this.logger.error('updateFeed error', err);
+    } finally {
+      // wait 30s for next feed
+      await new Promise((resolve) => setTimeout(resolve, 30 * 1e3));
+    }
+  }
 }


### PR DESCRIPTION
### 修改内容
扩展两个接口功能：

1. 支持通过/feeds/all.(json|rss|atom)接口和/feeds/:feed对标题进行过滤：使用title_include和title_exclude参数，支持使用`|`实现多个关键词的 或 逻辑
> {{ORIGIN_URL}}/feeds/all.atom?title_include=张三
> 
> {{ORIGIN_URL}}/feeds/MP_WXS_123.json?limit=30&title_include=张三|李四|王五&title_exclude=张三丰|赵六

2. 支持通过/feeds/:feed接口触发单个feedid更新：使用update=true参数
> {{ORIGIN_URL}}/feeds/MP_WXS_123.rss?update=true

### 目的
1. 满足部分用户在 issues 中提到的需求，如允许触发单个公众号的更新，避免全量更新请求过多

2. 希望未来通过[wewe-rss-extensions](https://github.com/wyn-ying/wewe-rss-extensions)组件，支持到更多扩展功能