### PR TITLE
Fix full text fetching

### DIFF
--- a/apps/server/src/feeds/feeds.service.ts
+++ b/apps/server/src/feeds/feeds.service.ts
@@ -98,6 +98,7 @@ export class FeedsService {
 
     const html = dirtyHtml
       .replace(/data-src=/g, 'src=')
+      .replace(/opacity: 0( !important)?;/g, '')
       .replace(/visibility: hidden;/g, '');
 
     const content =


### PR DESCRIPTION
This PR trys to fix #166.

The root cause is that Mr. Xiaolong Zhang added `style="opacity: 0;"` to the root `<div>` tag, making the fetched full text unreadable. Therefore we remove that god damn style attribute from the fetched HTML.