### PR TITLE
add wewe-rss.png as build-in base64 resource

### DIFF
--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Redirect, Render } from '@nestjs/common';
+import { Controller, Get, Response, Render } from '@nestjs/common';
 import { AppService } from './app.service';
 import { ConfigService } from '@nestjs/config';
 import { ConfigurationType } from './configuration';
+import { Response as Res } from 'express';
 
 @Controller()
 export class AppController {
@@ -21,8 +22,14 @@ export class AppController {
   }
 
   @Get('favicon.ico')
-  @Redirect('https://r2-assets.111965.xyz/wewe-rss.png', 302)
-  getFavicon() {}
+  getFavicon(
+    @Response() res: Res,
+  ) {
+    const imgContent = 'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAMAAABrrFhUAAAAAXNSR0IArs4c6QAAACRQTFRFR3BMsN2eke1itNumku5htNulm+l0ke1hc91PVc09OL0rGq0Z17o6fwAAAAV0Uk5TAGyAv79qLUngAAAFdUlEQVR42u3cQWPbIAyGYQlDkOT//3/X9bBLF3/gkgQJ3uuSA4+Ftxp3tNvtdrvdbrfb7Xa76zjNGjG9Ns65zl5O6WWrr15K0ZePS0xjSxUUewq4Oixz8MuPSw7W70EgVb+lMetfWiBV36Xg68cx/arqvhx8AHBpwPqX3QQ1RHnAACw6AjVI+f4ArD0CNUz57gCsPQI1UHl1gBp8B+B4A3RXQ/Uo3GnANVallD6DFA3gO14ZABBEB3j0CuRg6/8HUI6YAHgCgEB8gE6BGhigHKsDFF4doPDqAIVXBzhWByi8OsCxOkDh1QGO1QEKb4DFAY7VAcryAPxKADE7v7KvVFVkRoDjhQB6/shUZRkAPZ9kKvMAlJcB6HmVqkwCwK8CsBOlsQHOhkyjA+BUgwLI2ZxGnwCcRr8J4jQ6AE6jAdSzNw0GIP0CGgqg6tmdugLAieh3ZtZM4BUAJ6pqDQKuAXANCOoeACMAgeAA2MCiA2ADjQCAUyAQGAATaHAATGDBATCBSXAATCDBAbCABgfABLIMQBUDAh4B/p0NqqrcHAJxDACOg9oELNgDEdXebWBuAcCTr2Y0cwAA1gIM0LfUJYCe12nH9yT66TAWCHo0pq0CFgygX0DjHo83Ckjcs0FtEwgG0C9grgD635DAfhL5cFQbBCz04ag2+OlsADi1DgHsNy0APiE2GyFgDgCGngj+UBPPANhA4W3AXANgA4WbQHwD4OMwtAks+vsBijaB+AbAQyBoBHwDYAKDI+AbAP+0ZADKnAPgIVDwXEGcA2ABuf6Qhn9Fxq5HwLwD4B+Z9VpJvAPgW6GAEXAOgGfArkfAPQAWkMtPiHOA/nMQA3vAA4B8BwRaR8AbgJhdnwobGoEfPJ4AxG49Awd7wA2AWNMTYDAC4hZA7jz9wyPgAAC8/4ih7ApAnADozad/eA/MB4DnH1xD8AmXAHoBYEAL7AEXAHpeJfA+CG4C3n93GI+AXPyp+n8/AI+AXXBagPcErQ/A3AHY+ds94BzgRAn6hlwMVAgANDN6MR8SAQDtAXMNIP0AteOvAQ0xAWgPRAeAUyPPdSzAm6J1AyAAdQ0gN96PDQVQBwOoLwC8Bxq+Ys8BTvcvS2tsADwCNTQAFpD6v/QCQBwCSMcGwM99/PxLEAtovQFgXgCwgNRnXX1OZ3wegFP0f6O0X2Vz8FAUvxhs0jwxTzDnPRrDBibSPjDy5FdwzHy+IiONWA2T4gqgP1UzlVpDA+A2wAbYABtgA2yADbABNsAG2ACfA8jB1t8PsCdg8QlINVZlA3QC8OoAFPweiAHy6gAcewdgAFoeIMfeARiA1wGIPwIFAEQfgQcACD8C5SYAxx4ADEA59gAUggUbgH4ADr3+QrgUeAMUphUEHgAAlsKuv1BbKer6meILPMoIAOKQ6y/UUQq4fqaeUoq2/kKdpVjLL0zdpRx9/biUfB2EYYD+0lc5+7v4eP39cSll2DUbVGmKaUzHKIDy3phomMCYmX1zNCwuDtd/MI2L/V3+g4bmbv1MMwE8ivf1k7PxZxpd8OXjfO3+mQBcXf3xAA9Xqx8PkI+Wfrnq7/grIpoLIDM1xceYLT8bQKLmOCBAZuqIwwEk6oxjATB1x3MD5NpRplsdUQCYbsYhADLT7TgAQKJfxbMCpDGXH8eTAvCoy4/jKQFo2OXHsVOARKPiY0KAXEFMA+P5ABiMP42NpwMgMP7D49kAMrj7DY8nA2B0+cd3TAVAGVz+Dw0BvS0Gl/9DAvS+GFz+jxAc9MYSuPyfEGD6nECi98QA4DMEOTPRBAL09tLf3uzOBxiA+DEYgFUFmGhtAqK1BZgWi8H61yI4mJaM+SjlOJhpt9vtdrvdbrfbNfcHKaL2IynIYcEAAAAASUVORK5CYII='
+    const imgBuffer = Buffer.from(imgContent, 'base64');
+    res.setHeader('Content-Type', 'image/png');
+    res.send(imgBuffer);
+  }
 
   @Get('/dash*')
   @Render('index.hbs')

--- a/apps/server/src/app.controller.ts
+++ b/apps/server/src/app.controller.ts
@@ -41,6 +41,9 @@ export class AppController {
     return {
       weweRssServerOriginUrl,
       enabledAuthCode: !!code,
+      iconUrl: weweRssServerOriginUrl
+        ? `${weweRssServerOriginUrl}/favicon.ico`
+        : 'https://r2-assets.111965.xyz/wewe-rss.png'
     };
   }
 }

--- a/apps/server/src/feeds/feeds.service.ts
+++ b/apps/server/src/feeds/feeds.service.ts
@@ -252,11 +252,15 @@ export class FeedsService {
         take: limit,
       });
 
+      const { originUrl } =
+        this.configService.get<ConfigurationType['feed']>('feed')!;
       feedInfo = {
         id: 'all',
         mpName: 'WeWe-RSS All',
         mpIntro: 'WeWe-RSS 全部文章',
-        mpCover: 'https://r2-assets.111965.xyz/wewe-rss.png',
+        mpCover: originUrl
+          ? `${originUrl}/favicon.ico`
+          : 'https://r2-assets.111965.xyz/wewe-rss.png',
         status: 1,
         syncTime: 0,
         updateTime: Math.floor(Date.now() / 1e3),

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="" />
+    <link rel="icon" href="{{ iconUrl }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WeWe RSS</title>
     <meta name="description" content="更好的公众号订阅方式" />
@@ -12,12 +12,6 @@
     <script>
       window.__WEWE_RSS_SERVER_ORIGIN_URL__ = '{{ weweRssServerOriginUrl }}';
       window.__WEWE_RSS_ENABLED_AUTH_CODE__ = '{{ enabledAuthCode }}';
-      document.addEventListener('DOMContentLoaded', function() {
-        var icon = document.getElementById('icon');
-        icon.href = icon && window.__WEWE_RSS_SERVER_ORIGIN_URL__ !== ""
-          ? '{{ weweRssServerOriginUrl }}/favicon.ico'
-          : 'https://r2-assets.111965.xyz/wewe-rss.png';
-      });
     </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="https://r2-assets.111965.xyz/wewe-rss.png" />
+    <link rel="icon" href="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WeWe RSS</title>
     <meta name="description" content="更好的公众号订阅方式" />
@@ -11,7 +11,13 @@
     <div id="root"></div>
     <script>
       window.__WEWE_RSS_SERVER_ORIGIN_URL__ = '{{ weweRssServerOriginUrl }}';
-      window.__WEWE_RSS_ENABLED_AUTH_CODE__ = {{ enabledAuthCode }};
+      window.__WEWE_RSS_ENABLED_AUTH_CODE__ = '{{ enabledAuthCode }}';
+      document.addEventListener('DOMContentLoaded', function() {
+        var icon = document.getElementById('icon');
+        icon.href = icon && window.__WEWE_RSS_SERVER_ORIGIN_URL__ !== ""
+          ? '{{ weweRssServerOriginUrl }}/favicon.ico'
+          : 'https://r2-assets.111965.xyz/wewe-rss.png';
+      });
     </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -11,7 +11,7 @@ import {
 import { ThemeSwitcher } from './ThemeSwitcher';
 import { GitHubIcon } from './GitHubIcon';
 import { useLocation } from 'react-router-dom';
-import { appVersion } from '@web/utils/env';
+import { appVersion, serverOriginUrl } from '@web/utils/env';
 import { useEffect, useState } from 'react';
 
 const navbarItemLink = [
@@ -74,7 +74,10 @@ const Nav = () => {
                 width={28}
                 alt="WeWe RSS"
                 className="mr-2"
-                src="https://r2-assets.111965.xyz/wewe-rss.png"
+                src={ serverOriginUrl
+                  ? `${serverOriginUrl}/favicon.ico`
+                  : 'https://r2-assets.111965.xyz/wewe-rss.png'
+                }
               ></Image>
             </Badge>
             <p className="font-bold text-inherit">WeWe RSS</p>


### PR DESCRIPTION
针对 #220 的建议，将/favicon.ico接口利用起来，之前由 https://r2-assets.111965.xyz/wewe-rss.png 提供的png资源以base64形式写死在代码中。

如果用户通过参数 `SERVER_ORIGIN_URL` 配置了私有化部署地址，当需要请求png资源时，由SERVER_ORIGIN_URL/favicon.ico接口提供
如果用户没配置私有化部署地址，当需要请求png资源时，仍走原来的 https://r2-assets.111965.xyz/wewe-rss.png 接口