### PR TITLE
Put the full text in the content field.

### DIFF
--- a/apps/server/src/feeds/feeds.service.ts
+++ b/apps/server/src/feeds/feeds.service.ts
@@ -189,9 +189,9 @@ export class FeedsService {
       const mpName = feeds.find((item) => item.id === mpId)?.mpName || '-';
       const published = new Date(publishTime * 1e3);
 
-      let description = '';
+      let content = '';
       if (enableFullText) {
-        description = await this.tryGetContent(id);
+        content = await this.tryGetContent(id);
       }
 
       feed.addItem({
@@ -199,7 +199,7 @@ export class FeedsService {
         title,
         link: link,
         guid: link,
-        description,
+        content,
         date: published,
         image: picUrl,
         author: showAuthor ? [{ name: mpName }] : undefined,


### PR DESCRIPTION
JSON Feed (https://www.jsonfeed.org/version/1/)
和 Atom (https://www.ietf.org/rfc/rfc4287.txt)
都把全文放在 `content` 字段，而不是 `summary`字段。
如果在调用 feed 库的时候，把内容放在 description，那输出的时候全文内容会出现在 summary 字段中。而summary字段原本放的应该只是摘要,所以导致有些 feed 分析库出现了问题。

这段代码是我看了下 feed 库的 api 有这个 content 字段改的，还实际测试过。自己部署了下不知道为什么报没有读书帐号错误。